### PR TITLE
fix: add items-center class to flex container in SiteHeader component

### DIFF
--- a/components/site-header.tsx
+++ b/components/site-header.tsx
@@ -23,7 +23,7 @@ export const SiteHeader = () => {
                         <span className="sr-only font-bold">ns UI</span>
                     </Link>
 
-                    <div className="flex gap-1">
+                    <div className="flex gap-1 items-center">
                         <Button asChild size="sm" variant="ghost" className={cn('text-foreground/75 rounded-full', isActive('/hero-section') && 'text-foreground')}>
                             <Link href="/hero-section" className="!text-sm">
                                 Blocks


### PR DESCRIPTION
This pull request includes a small change to the `components/site-header.tsx` file. The change adds the `items-center` class to a `div` element to ensure that its child elements are vertically centered.