### PR TITLE
Fix pagination scroll behavior across website

### DIFF
--- a/apps/www/app/(discover)/components/pagination.tsx
+++ b/apps/www/app/(discover)/components/pagination.tsx
@@ -49,6 +49,11 @@ export function Pagination({ currentPage, totalPages, onPageChange, itemsPerPage
         return pages
     }
 
+    const handlePageChange = (page: number) => {
+        onPageChange(page)
+        window.scrollTo({ top: 0, behavior: 'smooth' })
+    }
+
     const startItem = (currentPage - 1) * itemsPerPage + 1
     const endItem = Math.min(currentPage * itemsPerPage, totalItems)
 
@@ -77,7 +82,7 @@ export function Pagination({ currentPage, totalPages, onPageChange, itemsPerPage
                 {totalPages > 1 && (
                     <div className="flex items-center gap-0.5">
                         <button
-                            onClick={() => onPageChange(currentPage - 1)}
+                            onClick={() => handlePageChange(currentPage - 1)}
                             disabled={currentPage === 1}
                             className="hover:bg-muted active:scale-98 flex h-7 w-9 items-center justify-center rounded-md transition-all disabled:cursor-not-allowed disabled:opacity-30"
                             aria-label="Previous page">
@@ -98,7 +103,7 @@ export function Pagination({ currentPage, totalPages, onPageChange, itemsPerPage
                             return (
                                 <button
                                     key={page}
-                                    onClick={() => onPageChange(page as number)}
+                                    onClick={() => handlePageChange(page as number)}
                                     className={cn('active:scale-98 flex h-7 w-9 items-center justify-center rounded-md text-sm transition-all', currentPage === page ? 'bg-card ring-foreground/6.5 text-foreground font-medium shadow-md shadow-black/5 ring-1' : 'hover:bg-muted text-foreground')}
                                     aria-label={`Page ${page}`}
                                     aria-current={currentPage === page ? 'page' : undefined}>
@@ -108,7 +113,7 @@ export function Pagination({ currentPage, totalPages, onPageChange, itemsPerPage
                         })}
 
                         <button
-                            onClick={() => onPageChange(currentPage + 1)}
+                            onClick={() => handlePageChange(currentPage + 1)}
                             disabled={currentPage === totalPages}
                             className="hover:bg-muted active:scale-98 flex h-7 w-9 items-center justify-center rounded-md transition-all disabled:cursor-not-allowed disabled:opacity-30"
                             aria-label="Next page">


### PR DESCRIPTION
## Summary
This PR improves the pagination experience across the website by automatically scrolling to the top whenever users navigate between pages using the shared pagination component. [Fixes #51](https://github.com/tailark/blocks/issues/51)

Previously, pagination changes preserved the current scroll position, causing users to land at the bottom or middle of the next page. This required manual scrolling and created an inconsistent browsing experience.

With this fix, all pagination transitions now smoothly scroll users back to the top of the page.

## Changes Made

Added smooth scroll-to-top behavior inside the pagination page change handler:

```ts
const handlePageChange = (page: number) => {
    onPageChange(page)
    window.scrollTo({ top: 0, behavior: 'smooth' })
}
```

## Before
- Pagination navigation worked correctly
- Scroll position persisted between page changes
- Users often landed at the bottom of newly loaded pages

## After
- Pagination navigation still works correctly
- Page automatically scrolls to the top after pagination changes
- Consistent and improved UX across the website

## Testing
- Verified pagination behavior across multiple pages
- Tested smooth scrolling functionality
- Confirmed no impact on existing pagination logic

## Demo

### Before
https://github.com/user-attachments/assets/1d5220c2-5617-45c8-8201-dc5cd332c630

### After
https://github.com/user-attachments/assets/f04374f3-4e02-4152-8b94-393bc4ccd7cb